### PR TITLE
[feats]: file loading with filepath tracking + menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A minimal, cross-platform Time Tracking App made with C++ & Qt
+A minimal, cross-platform Time Tracking App (C++/Qt)
 
 On Ubuntu (GNOME):
 ![A screenshot of the main page of the app on Ubuntu (GNOME)](tta-main-gnome-screenshot.png)
@@ -31,7 +31,7 @@ On Ubuntu (GNOME):
 
 <u>TODO: LATER</u> <br/>
 ☐ Rethink the window size policy (is set fixed for now for simplicity) <br/>
-☐ More flexibily with save files (edit save file location by user?) <br/>
+☐ Project categories? <br/>
 
 ## Building and compatibility
 
@@ -42,4 +42,9 @@ Developed on Linux (Ubuntu) with QtCreator and Windows with VS2022 (Qt plugin an
 Tested on Linux Ubuntu and Windows 10.
 
 #### Note
-Qt projects built with CMake might have build issues related to the moc pipepline (the include of to-be-generated Qt' ui files). If so, you'll find the ui_*.h files in your /out/build directory that is generated at every CMake launch. This issue is especially happening on Windows, if you're using Visual Studio you might need to either : ***Reconfigure your project using CMake*** (and clean build) or ***clean the project (also possible to delete the build directory) and restart VS as it will trigger the necessay CMake rebuilding.***
+Qt projects built with CMake might have build issues related to the moc pipepline (the include of to-be-generated Qt' ui files). 
+If so, you'll find the ui_*.h files in your /out/build directory that is generated at every CMake launch. 
+This issue is especially happening on Windows, if you're using Visual Studio you might need to either : 
+***Reconfigure your project using CMake*** (and clean build) 
+or 
+***Clean the project (also possible to delete the build directory) and restart VS as it will trigger the necessay CMake rebuilding.***

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ On Ubuntu (GNOME):
 <u>VERSION 0.1</u> <br/>
 🗹 Create projects, save and load them from disk <br/>
 🗹 Edit project : rename, delete <br/>
-🗹 Start and stop session, added automatically to project <br/>
-🗹 Display project stats by processing sessions data <br/>
-🗹 Use colors to distringuish projects and assign new custom one via dialog picker <br/>
+🗹 Dynamic project loading (default directory for saves + file loading if saved elsewhere) <br/>
+🗹 Start and stop session, added automatically to project stats <br/>
+🗹 Display various project stats by processing sessions data (next: calendar, see below 0.X) <br/>
+🗹 Use customizable colors to distinguish projects <br/>
 🗹 Display "Edit" and "Stats" features inside a collapsable panel <br/> 
 🗹 Manual add session (also for testing purpose) <br/>
-🗹 Connect menu bar actions + finish to implement the necessary features for this (single file load, about etc. menu) <br/>
 ☐ JSON support <br/>
 
 <u>VERSION 0.X</u> <br/>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ On Ubuntu (GNOME):
 🗹 Use colors to distringuish projects and assign new custom one via dialog picker <br/>
 🗹 Display "Edit" and "Stats" features inside a collapsable panel <br/> 
 🗹 Manual add session (also for testing purpose) <br/>
-☐ Connect menu bar actions + finish to implement the necessary features for this (single file load, about menu) <br/>
+🗹 Connect menu bar actions + finish to implement the necessary features for this (single file load, about etc. menu) <br/>
+☐ JSON support <br/>
 
 <u>VERSION 0.X</u> <br/>
 ☐ Manual delete session (and maybe better, thus dedicated UI for Sessions handling? see below) <br/>

--- a/src/ProjectData.cpp
+++ b/src/ProjectData.cpp
@@ -3,13 +3,13 @@
 //static
 int ProjectData::currentProjectCount = 0;
 
-ProjectData::ProjectData(const QString& name, const QString& filepath) : projectName(name), filepath(filepath), ID(currentProjectCount)
+ProjectData::ProjectData(const QString& name, const QString& filepath) : m_projectName(name), m_filepath(filepath), m_ID(currentProjectCount)
 {
     currentSession = nullptr;
-    currentSessionID = 0;
-    sessions = QList<Session>();
+    m_currentSessionID = 0;
+    m_sessions = QList<Session>();
     currentProjectCount++;
-    projectColorQSS = newProjectColorQSS();
+    m_projectColorQSS = newProjectColorQSS();
 }
 
 ProjectData::~ProjectData()
@@ -24,7 +24,7 @@ void ProjectData::start()
         return;
     }
 
-    currentSession = new Session(currentSessionID);
+    currentSession = new Session(m_currentSessionID);
     currentSession->start();
 }
 
@@ -36,7 +36,7 @@ void ProjectData::stop()
     }
 
     currentSession->end();
-    sessions.push_back(*currentSession);
+    m_sessions.push_back(*currentSession);
     currentSession = nullptr;
 
     saveToFile();
@@ -49,7 +49,7 @@ void ProjectData::deleteSaveFile()
     QFile f = QFile(filepath);
     f.remove();
 
-    emit deletedFile(filepath);
+    emit signalDeletedFile(filepath);
 }
 
 bool ProjectData::isRunning()
@@ -73,15 +73,15 @@ bool ProjectData::addCustomSessionFrom(QDateTime& start, QDateTime& end)
         return false;
     }
 
-    Session s = Session(currentSessionID, start, end);
-    sessions.push_back(s);
+    Session s = Session(m_currentSessionID, start, end);
+    m_sessions.push_back(s);
     saveToFile();
     return true;
 }
 
 int ProjectData::getSessionsCount()
 {
-    return sessions.count();
+    return m_sessions.count();
 }
 
 QDateTime ProjectData::getCurrentSessionStartTime()
@@ -92,7 +92,7 @@ QDateTime ProjectData::getCurrentSessionStartTime()
 quint64 ProjectData::getTotalDuration() const
 {
     quint64 total = 0;
-    for (const Session& session : sessions) {
+    for (const Session& session : m_sessions) {
         total += session.getDuration();
     }
     return total;
@@ -117,15 +117,15 @@ QString ProjectData::getAvgSessionDuration()
 
 int ProjectData::getActiveDaysCount()
 {
-    if (sessions.isEmpty()) {
+    if (m_sessions.isEmpty()) {
         return 0;
     }
 
     int activeDays = 1;
 
-    QDate lastDay = sessions.first().getStartDateTime().date();
+    QDate lastDay = m_sessions.first().getStartDateTime().date();
 
-    for (Session& s : sessions)
+    for (Session& s : m_sessions)
     {
         QDate sDay = s.getStartDateTime().date();
         if (sDay != lastDay) {
@@ -150,55 +150,57 @@ QString ProjectData::getAvgTimePerActiveDay()
 
 bool ProjectData::saveToFile()
 {
-    QString filepath = getFilepath();
-    qDebug() << "Saving to file " << filepath;
-    QFile file(filepath);
-    if (!file.open(QIODevice::WriteOnly))
+    QString verifiedFilepath = getFilepath();
+    if (verifiedFilepath == "")
     {
-        qDebug() << "ERROR: Couldn't save file at " << filepath << ". Error: " << file.errorString();
+        qDebug() << "ERROR: Couldn't save file for project " << m_projectName << " : no filepath";
         return false;
     }
+    
+    QFile file(verifiedFilepath);
+    if (!file.open(QIODevice::WriteOnly))
+    {
+        qDebug() << "ERROR: Couldn't save file at " << verifiedFilepath << ". Error: " << file.errorString();
+        return false;
+    }
+
+    qDebug() << "Saving to file " << verifiedFilepath;
 
     QDataStream out(&file);
     out.setVersion(QDataStream::Qt_DefaultCompiledVersion);
 
-    out << projectName;
+    out << m_projectName;
 
-    out << projectColorQSS;
+    out << m_projectColorQSS;
 
-    out << quint32(sessions.count());
+    out << quint32(m_sessions.count());
 
-    qDebug() << "Serializing " << quint32(sessions.count()) << " sessions...";
+    qDebug() << "Serializing " << quint32(m_sessions.count()) << " sessions...";
 
-    for (const Session& session : sessions)
+    for (const Session& session : m_sessions)
     {
         qDebug() << "Session " << session.getID() << " saved";
         session.serialize(out);
     }
 
-    emit newOpenedFile(filepath);
-
     return true;
 }
 
-QString ProjectData::getFilepath()
+QString ProjectData::getFilepath(bool checkForExistantFile)
 {
-    if (filepath == "")
-    {
-        qDebug() << "ERROR! No filepath registered for project " << projectName;
-        // setting default filepath
-        setFilepath(QString(QDir::currentPath() + Epochpp::DEF_SAVE_LOCATION + projectName + "." + Epochpp::DEF_BIN_FILE_EXTENSION));
-    } else if(!QFile::exists(filepath)) {
-        qDebug() << "ERROR! Couldn't reach registered path at " << filepath << " for "<< projectName;
-        // setting default filepath
-        setFilepath(QString(QDir::currentPath() + Epochpp::DEF_SAVE_LOCATION + projectName + "." + Epochpp::DEF_BIN_FILE_EXTENSION));
-    }
-    return filepath;
+    if (m_filepath == "")
+        qDebug() << "ERROR! No filepath registered for project " << m_projectName;
+    
+    if (checkForExistantFile && !QFile::exists(m_filepath))
+        qDebug() << "WARNING! Project " << m_projectName << " save filepath point to a non-existant file: " << m_filepath;
+
+    return m_filepath;
 }
 
 void ProjectData::setFilepath(QString& filepath)
 {
-    this->filepath = filepath;
+    m_filepath = filepath;
+    emit signalTrackFile(m_filepath);
 }
 
 bool ProjectData::loadFromFile(const QString& filepath)
@@ -214,73 +216,73 @@ bool ProjectData::loadFromFile(const QString& filepath)
     QDataStream in(&file);
     in.setVersion(QDataStream::Qt_DefaultCompiledVersion);
 
-    /*
-    in >> this->filepath;
+    in >> m_projectName;
 
-    if (this->filepath != filepath)
-    {
-        qDebug() << "ERROR: loaded filepath is different from the real filepath the file is being loaded from";
-        qDebug() << "current filepath: " << filepath;
-        qDebug() << "loaded filepath: " << this->filepath;
-        qDebug() << "overwriting filepath with current filepath";
-        this->filepath = filepath;
-    }
-    */
-
-    in >> projectName;
-
-    in >> projectColorQSS;
+    in >> m_projectColorQSS;
 
     quint32 sessionCount;
     in >> sessionCount;
 
     // wip?
-    if (currentSessionID != 0) {
+    if (m_currentSessionID != 0) {
         qDebug() << "Clearing sessions...";
-        sessions.clear();
+        m_sessions.clear();
         qDebug() << "Resetting current session ID";
-        currentSessionID = 0;
+        m_currentSessionID = 0;
     }
 
     // Session increment itself the int we're giving in order to keep track of the Session ID in a signel place
-    while (currentSessionID < sessionCount) {
-        Session session(currentSessionID);
+    while (m_currentSessionID < sessionCount) {
+        Session session(m_currentSessionID);
         session.deserialize(in);
-        sessions.append(session);
+        m_sessions.append(session);
     }
-
-    saveToFile();
 
     return true;
 }
 
 QString& ProjectData::getProjectName()
 {
-    return projectName;
+    return m_projectName;
 }
 
 void ProjectData::rename(const QString& newProjectName)
 {
     if (newProjectName.isEmpty()) {
-        qDebug() << "WARNING: Tried to rename project (data level) but new project name is empty. Aborting" << Qt::endl;
+        qDebug() << "WARNING: Tried to rename project but new project name is empty. Aborting" << Qt::endl;
         return;
     }
 
     //delete soon-to-be-old file
-    deleteSaveFile();
+    deleteSaveFile(); // this fn also takes care of the signal emitting for untracking old project filepath
 
-    projectName = newProjectName;
+    QString oldProjectName = m_projectName;
+    m_projectName = newProjectName;
+    QString oldFilepath = getFilepath();
+    QString newFilepath;
+    if (oldFilepath == "")
+    {
+        qDebug() << "WARNING: Renamed a project without a registered filepath. Saving it at default path";
+        newFilepath = QString(QDir::currentPath() + Epochpp::DEF_SAVE_LOCATION + newProjectName + "." + Epochpp::DEF_BIN_FILE_EXTENSION);
+    }
+    else
+    {
+        QString end(oldProjectName + ".timesheet");
+        newFilepath = oldFilepath.remove(end, Qt::CaseInsensitive);
+        newFilepath += QString(m_projectName + ".timesheet");
+    }
 
+    setFilepath(newFilepath);
     saveToFile();
-}
+} 
 
 QString ProjectData::getProjectColorQSS()
 {
-    return this->projectColorQSS;
+    return m_projectColorQSS;
 }
 
 void ProjectData::setProjectColorQSS(QColor newColor)
 {
-    projectColorQSS = QString("color: rgb(%1, %2, %3)").arg(newColor.red()).arg(newColor.green()).arg(newColor.blue());
+    m_projectColorQSS = QString("color: rgb(%1, %2, %3)").arg(newColor.red()).arg(newColor.green()).arg(newColor.blue());
     saveToFile();
 }

--- a/src/ProjectData.h
+++ b/src/ProjectData.h
@@ -11,12 +11,14 @@
 #include "Session.h"
 #include "utils.h"
 
-class ProjectData
+class ProjectData : public QObject
 {
+
+    Q_OBJECT
 // METHODS //
 
 public:
-    ProjectData(const QString& name);
+    ProjectData(const QString& name, const QString& filepath = "");
     ~ProjectData();
 
     void start();
@@ -32,8 +34,8 @@ public:
     QString getAvgTimePerActiveDay();
     bool saveToFile();
     QString getFilepath();
-    bool loadFromFile(const QString& filePath);
-    bool loadFromSave(const QString& projectName);
+    void setFilepath(QString& filepath);
+    bool loadFromFile(const QString& filepath);
     QString& getProjectName();
     void rename(const QString& newProjectName);
     QString getProjectColorQSS();
@@ -43,6 +45,10 @@ public:
 private:
     static QString newProjectColorQSS();
 
+signals:
+    void newOpenedFile(const QString& filepath);
+    void deletedFile(QString& filepath);
+
 // ATTRIBUTES //
 
 public:
@@ -50,6 +56,7 @@ public:
     static int currentProjectCount;
 
 private:
+    QString filepath;
     QString projectName;
     QString projectColorQSS;
     int currentSessionID;

--- a/src/ProjectData.h
+++ b/src/ProjectData.h
@@ -18,7 +18,7 @@ class ProjectData : public QObject
 // METHODS //
 
 public:
-    ProjectData(const QString& name, const QString& filepath = "");
+    ProjectData(const QString& name, const QString& filepath);
     ~ProjectData();
 
     void start();
@@ -33,7 +33,7 @@ public:
     int getActiveDaysCount();
     QString getAvgTimePerActiveDay();
     bool saveToFile();
-    QString getFilepath();
+    QString getFilepath(bool checkForExistantFile = true);
     void setFilepath(QString& filepath);
     bool loadFromFile(const QString& filepath);
     QString& getProjectName();
@@ -46,21 +46,21 @@ private:
     static QString newProjectColorQSS();
 
 signals:
-    void newOpenedFile(const QString& filepath);
-    void deletedFile(QString& filepath);
+    void signalTrackFile(QString& filepath);
+    void signalDeletedFile(QString& filepath);
 
 // ATTRIBUTES //
 
 public:
-    int ID;
+    int m_ID;
     static int currentProjectCount;
 
 private:
-    QString filepath;
-    QString projectName;
-    QString projectColorQSS;
-    int currentSessionID;
+    QString m_filepath;
+    QString m_projectName;
+    QString m_projectColorQSS;
+    int m_currentSessionID;
     Session* currentSession = nullptr;
-    QList<Session> sessions;
+    QList<Session> m_sessions;
 };
 

--- a/src/ProjectWidget.cpp
+++ b/src/ProjectWidget.cpp
@@ -117,7 +117,7 @@ void ProjectWidget::rename(const QString& newProjectName)
 void ProjectWidget::askDelete()
 {
     int res = MsgBoxGen::throwNewMessageBox(Epochpp::g_mainWindow,
-                            QString("Are you sure you want to delete \"%1\" project?").arg(project->getProjectName()),
+                            QString("Are you sure you want to delete \"%1\" project?\nThe .timesheet file will also be deleted").arg(project->getProjectName()),
                             QMessageBox::Ok | QMessageBox::Cancel,
                             QMessageBox::Cancel,
                             "Project Delete")->exec();

--- a/src/ProjectWidget.cpp
+++ b/src/ProjectWidget.cpp
@@ -128,7 +128,7 @@ void ProjectWidget::askDelete()
 
 void ProjectWidget::immediateDelete()
 {
-    emit requestProjectDeletion(project->ID);
+    emit requestProjectDeletion(project->m_ID);
     //bool deletionSuccessful = ...;
     //if(deletionSuccessful)
     // ... REMOVE WIDGET

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1,14 +1,14 @@
 #include "Session.h"
 
-Session::Session(int& ID) : ID(ID)
+Session::Session(int& ID) : m_ID(ID)
 {
-	startTime = QDateTime();
-	endTime = QDateTime();
+	m_startTime = QDateTime();
+	m_endTime = QDateTime();
 	qDebug() << "New empty Session created (" << ID << ")";
 	ID++;
 }
 
-Session::Session(int& ID, QDateTime start, QDateTime end) : ID(ID), startTime(start), endTime(end)
+Session::Session(int& ID, QDateTime start, QDateTime end) : m_ID(ID), m_startTime(start), m_endTime(end)
 { 
 	qDebug() << "New assigned Session created (" << ID << ")";
 	ID++;
@@ -16,51 +16,51 @@ Session::Session(int& ID, QDateTime start, QDateTime end) : ID(ID), startTime(st
 
 void Session::start()
 {
-	if (startTime.isValid()) {
+	if (m_startTime.isValid()) {
 		qDebug() << "Tried to start session but this session already has a startTime. Aborting.";
 		return;
 	}
 
-	startTime = QDateTime::currentDateTime();
+	m_startTime = QDateTime::currentDateTime();
 }
 
 void Session::end()
 {
-	if (endTime.isValid()) {
+	if (m_endTime.isValid()) {
 		qDebug() << "Tried to start session but this session already has an endTime. Aborting.";
 		return;
 	}
 
-	endTime = QDateTime::currentDateTime();
+	m_endTime = QDateTime::currentDateTime();
 }
 
 quint64 Session::getDuration() const
 {
-	if (!startTime.isValid() || !endTime.isValid()) {
+	if (!m_startTime.isValid() || !m_endTime.isValid()) {
 		qDebug() << "Missing data. Cannot return session duration";
 		return 0;
 	}
 
-	return startTime.secsTo(endTime);
+	return m_startTime.secsTo(m_endTime);
 }
 
 const QDateTime& Session::getStartDateTime() const
 {
-	return startTime;
+	return m_startTime;
 }
 
 const int& Session::getID() const
 {
-	return ID;
+	return m_ID;
 }
 
 void Session::serialize(QDataStream& out) const {
-	out << startTime;
-	out << endTime;
+	out << m_startTime;
+	out << m_endTime;
 }
 
 void Session::deserialize(QDataStream& in) {
 	qint64 duration;
-	in >> startTime;
-	in >> endTime;
+	in >> m_startTime;
+	in >> m_endTime;
 }

--- a/src/Session.h
+++ b/src/Session.h
@@ -22,8 +22,8 @@ public:
 // ATTRIBUTES //
 
 private:
-    QDateTime startTime;
-    QDateTime endTime;
-    int ID;
+    QDateTime m_startTime;
+    QDateTime m_endTime;
+    int m_ID;
 };
 

--- a/src/TimeTrackingApp.cpp
+++ b/src/TimeTrackingApp.cpp
@@ -17,6 +17,9 @@ TimeTrackingApp::TimeTrackingApp(QWidget *parent)
     connect(ui->actionNew, &QAction::triggered, this, &TimeTrackingApp::askNewProject);
     connect(ui->actionLoad_Project, &QAction::triggered, this, &TimeTrackingApp::loadSingleProject);
     connect(ui->actionLoad_All_Projects_From, &QAction::triggered, this, &TimeTrackingApp::loadAllProjectsFrom);
+    connect(ui->actionAbout, &QAction::triggered, this, &TimeTrackingApp::displayAbout);
+    connect(ui->actionHelp, &QAction::triggered, this, &TimeTrackingApp::displayHelp);
+    connect(ui->actionReport_a_Bug, &QAction::triggered, this, &TimeTrackingApp::displayReportBug);
 
     // UI Layout
 
@@ -492,4 +495,59 @@ void TimeTrackingApp::configureStyleSheet()
     styleSheetFile.close();
 
     setStyleSheet(mainStyleSheet);
+}
+
+void TimeTrackingApp::displayAbout()
+{
+    QMessageBox aboutBox;
+    aboutBox.setWindowTitle("About Epoch++");
+    aboutBox.setText(
+        "<p>Epoch++ is a free, open-source software licensed under GPL3, developed using the Qt framework</p>"
+        "<p>Epoch++ aims to help you easily and locally track your progress on projects and hobbies.</p>"
+        "<p>Bug? Missing feature? Want to improve the software or report something?</p>"
+        "<p>You can contribute on the GitHub page where the project is hosted: "
+        "</br><a href='https://github.com/aseiis/epochplusplus'>https://github.com/aseiis/epochplusplus</a></p>"
+        );
+
+    aboutBox.setTextFormat(Qt::RichText);
+    aboutBox.setStandardButtons(QMessageBox::Ok);
+
+    aboutBox.exec();
+}
+
+void TimeTrackingApp::displayHelp()
+{
+    QMessageBox helpBox;
+    helpBox.setWindowTitle("Help");
+    helpBox.setText(
+        "<h3>How to use Epoch++?</h3>"
+        "<p>Epoch++ let you create new projects and track the time you've spent on them.</p>"
+        "<p>To create your first project, click on the 'New Project' button."
+        "Now your project has been created: you can see the project card displaying basic information about it: the time you spent on the current session, "
+        "when a session is running, as well as the total time spent on that project</p>"
+        "<p>You can now start the first session of your project by pressing the play button. It'll start a session that you can stop at any time.</p>"
+        "<p>During the session, its duration is displayed on the project card. "
+        "After you've stopped your session, the data of this session will be added to the project statistics.</p>"
+        "<p>To see more informations and statistics about a specific project, click on the 'More...' button</p>"
+    );
+
+    helpBox.setTextFormat(Qt::RichText);
+    helpBox.setStandardButtons(QMessageBox::Ok);
+
+    helpBox.exec();
+}
+
+void TimeTrackingApp::displayReportBug()
+{
+    QMessageBox reportBugBox;
+    reportBugBox.setWindowTitle("Report a bug");
+    reportBugBox.setText(
+        "<p>If you witnessed a bug or have any suggestion about the software, you can open an issue on the GitHub page where Epoch++ is hosted:</p>"
+        "<p><a href='https://github.com/aseiis/epochplusplus'>https://github.com/aseiis/epochplusplus</a></p>"
+    );
+
+    reportBugBox.setTextFormat(Qt::RichText);
+    reportBugBox.setStandardButtons(QMessageBox::Ok);
+
+    reportBugBox.exec();
 }

--- a/src/TimeTrackingApp.cpp
+++ b/src/TimeTrackingApp.cpp
@@ -15,7 +15,7 @@ TimeTrackingApp::TimeTrackingApp(QWidget *parent)
     // self UI connect
     connect(ui->newProjectPushButton, &QPushButton::pressed, this, &TimeTrackingApp::askNewProject);
     connect(ui->actionNew, &QAction::triggered, this, &TimeTrackingApp::askNewProject);
-    connect(ui->actionLoad, &QAction::triggered, this, &TimeTrackingApp::loadSingleProject);
+    connect(ui->actionLoad_Project, &QAction::triggered, this, &TimeTrackingApp::loadSingleProject);
     connect(ui->actionLoad_All_Projects_From, &QAction::triggered, this, &TimeTrackingApp::loadAllProjectsFrom);
 
     // UI Layout
@@ -275,7 +275,7 @@ void TimeTrackingApp::loadAllProjectsFrom()
 void TimeTrackingApp::loadSingleProject()
 {
     QString fileName = QFileDialog::getOpenFileName(this,
-        tr("Load project"), "",
+        tr("Load Project"), "",
         tr("TIMESHEET (*.timesheet, *.TIMESHEET)"));
 
     if (fileName.isEmpty())

--- a/src/TimeTrackingApp.h
+++ b/src/TimeTrackingApp.h
@@ -2,6 +2,10 @@
 
 #include <QtWidgets/QMainWindow>
 #include <QInputDialog>
+#include <QFileDialog>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
 #include <qmessagebox.h>
 
 #include "ProjectData.h"
@@ -25,11 +29,18 @@ public:
     ~TimeTrackingApp();
 
 private:
+    void initOpenedFiles();
     void initSavesDir();
-    void loadAndDisplayProjects();
+    void loadFrom(QDir savesDir);
+    void loadAt(const QString filepath, bool trackingCheckEnabled=true);
+    void loadAllOpenedProjects();
+    void loadProjectsFromDefaultDirectory();
+    void loadAllProjectsFrom();
+    void loadSingleProject();
     void askNewProject();
     void createProject(const QString& newProjectName = QString("__unnammed_project"));
     bool isProjectNameUnique(QString& testProjectName);
+    bool isProjectAlreadyTracked(const QString& filepath);
     void newProjectWidget(ProjectData* project);
     /*
     void refreshProjectsDisplay();
@@ -41,6 +52,8 @@ private:
 
 public slots:
     void deleteProject(int projectID);
+    void untrackProject(const QString& filepath);
+    void addToOpenedFiles(const QString& projectFilepath);
 
 // SIGNALS //
 

--- a/src/TimeTrackingApp.h
+++ b/src/TimeTrackingApp.h
@@ -54,6 +54,9 @@ public slots:
     void deleteProject(int projectID);
     void untrackProject(const QString& filepath);
     void addToOpenedFiles(const QString& projectFilepath);
+    void displayAbout();
+    void displayHelp();
+    void displayReportBug();
 
 // SIGNALS //
 

--- a/src/TimeTrackingApp.h
+++ b/src/TimeTrackingApp.h
@@ -31,11 +31,13 @@ public:
 private:
     void initOpenedFiles();
     void initSavesDir();
+    void createConfigFile();
     void loadFrom(QDir savesDir);
     void loadAt(const QString filepath, bool trackingCheckEnabled=true);
     void loadAllOpenedProjects();
     void loadProjectsFromDefaultDirectory();
     void createProject(const QString& newProjectName = QString("__unnammed_project"));
+    void useProject(ProjectData* projectData);
     bool isProjectNameUnique(QString& testProjectName);
     bool isProjectAlreadyTracked(const QString& filepath);
     void newProjectWidget(ProjectData* project);
@@ -52,8 +54,8 @@ public slots:
     void loadSingleProject();
     void loadAllProjectsFrom();
     void deleteProject(int projectID);
+    void trackProject(const QString& projectFilepath);
     void untrackProject(const QString& filepath);
-    void addToOpenedFiles(const QString& projectFilepath);
     void displayAbout();
     void displayHelp();
     void displayReportBug();

--- a/src/TimeTrackingApp.h
+++ b/src/TimeTrackingApp.h
@@ -35,9 +35,6 @@ private:
     void loadAt(const QString filepath, bool trackingCheckEnabled=true);
     void loadAllOpenedProjects();
     void loadProjectsFromDefaultDirectory();
-    void loadAllProjectsFrom();
-    void loadSingleProject();
-    void askNewProject();
     void createProject(const QString& newProjectName = QString("__unnammed_project"));
     bool isProjectNameUnique(QString& testProjectName);
     bool isProjectAlreadyTracked(const QString& filepath);
@@ -51,6 +48,9 @@ private:
 // SLOTS //
 
 public slots:
+    void askNewProject();
+    void loadSingleProject();
+    void loadAllProjectsFrom();
     void deleteProject(int projectID);
     void untrackProject(const QString& filepath);
     void addToOpenedFiles(const QString& projectFilepath);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -35,7 +35,7 @@ QString Epochpp::secsToHM(quint64 totalSeconds)
 
 QMessageBox* MsgBoxGen::throwNewMessageBox(QMainWindow* mainWindow, QString text, QFlags<QMessageBox::StandardButton> buttons, QMessageBox::StandardButton defaultButton, QString windowTitle)
 {
-    QMessageBox* msgBox = new QMessageBox(mainWindow->centralWidget());
+    QMessageBox* msgBox = new QMessageBox(mainWindow);
 
     if (windowTitle == "")
         msgBox->setWindowTitle(Epochpp::APP_NAME);

--- a/src/utils.h
+++ b/src/utils.h
@@ -11,6 +11,8 @@ namespace Epochpp {
     inline const char* DEF_BIN_FILE_EXTENSION = "timesheet";
     inline const char* DEF_SAVE_LOCATION = "/saves/";
 
+    inline const char* CFG_FILE_PATH = "epochpp.cfg";
+
     // GLOBAL ACCESS //
 
     inline QMainWindow* g_mainWindow = nullptr;

--- a/ui/TimeTrackingApp.ui
+++ b/ui/TimeTrackingApp.ui
@@ -183,6 +183,7 @@
     </property>
     <addaction name="actionAbout"/>
     <addaction name="actionHelp"/>
+    <addaction name="actionReport_a_Bug"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
@@ -205,7 +206,7 @@
   </action>
   <action name="actionCurrent_Project_Details">
    <property name="text">
-    <string>Current project details...</string>
+    <string>Current project details</string>
    </property>
   </action>
   <action name="actionAbout">
@@ -216,6 +217,11 @@
   <action name="actionHelp">
    <property name="text">
     <string>Help</string>
+   </property>
+  </action>
+  <action name="actionReport_a_Bug">
+   <property name="text">
+    <string>Report a Bug</string>
    </property>
   </action>
  </widget>

--- a/ui/TimeTrackingApp.ui
+++ b/ui/TimeTrackingApp.ui
@@ -165,16 +165,19 @@
      <string>File</string>
     </property>
     <addaction name="actionNew"/>
-    <addaction name="actionLoad"/>
+    <addaction name="actionLoad_Project"/>
     <addaction name="actionLoad_All_Projects_From"/>
    </widget>
-   <widget class="QMenu" name="menuAbout">
+   <widget class="QMenu" name="menuEdit">
+    <property name="enabled">
+     <bool>true</bool>
+    </property>
     <property name="title">
      <string>Edit</string>
     </property>
-    <addaction name="actionEpoch"/>
+    <addaction name="actionCurrent_Project_Details"/>
    </widget>
-   <widget class="QMenu" name="menu">
+   <widget class="QMenu" name="menuMisc">
     <property name="title">
      <string>?</string>
     </property>
@@ -182,17 +185,17 @@
     <addaction name="actionHelp"/>
    </widget>
    <addaction name="menuFile"/>
-   <addaction name="menuAbout"/>
-   <addaction name="menu"/>
+   <addaction name="menuEdit"/>
+   <addaction name="menuMisc"/>
   </widget>
   <action name="actionNew">
    <property name="text">
     <string>New</string>
    </property>
   </action>
-  <action name="actionLoad">
+  <action name="actionLoad_Project">
    <property name="text">
-    <string>Load...</string>
+    <string>Load Project...</string>
    </property>
   </action>
   <action name="actionLoad_All_Projects_From">
@@ -200,7 +203,7 @@
     <string>Load All Projects From...</string>
    </property>
   </action>
-  <action name="actionEpoch">
+  <action name="actionCurrent_Project_Details">
    <property name="text">
     <string>Current project details...</string>
    </property>


### PR DESCRIPTION
1. Projects can now be loaded from directories different from the default one [saves/], either with a single file picked and loaded or by giving a directory where all the projects will be loaded. Whenever a project is loaded OR created, its filepath (where it is saved) is tracked in the config [.cfg] file.

Note: every project lives in its separate .timesheet file. Each time the project is renammed, the file is deleted and re-written with a new filepath based on the new project name.

2. Menu contents for the '?' toolbar button added: "About", "Help" and "Report a bug"